### PR TITLE
added mat_foce_vlan conf. param. to netwalker

### DIFF
--- a/lib/Manoc/App/Netwalker.pm
+++ b/lib/Manoc/App/Netwalker.pm
@@ -176,6 +176,7 @@ sub run {
                   iface_filter         => $self->config->{Netwalker}->{iface_filter}       || 1,
                   ignore_portchannel   => $self->config->{Netwalker}->{ignore_portchannel} || 1,
                   vtp_server           => $self->config->{Netwalker}->{vtp_server} || '',
+                  mat_force_vlan       => $self->config->{Netwalker}->{mat_force_vlan} || '',
                  ); 
 
    #parse vtp servers

--- a/lib/Manoc/Netwalker/DeviceUpdater.pm
+++ b/lib/Manoc/Netwalker/DeviceUpdater.pm
@@ -95,14 +95,16 @@ sub _build_source {
     my $entry = $self->entry;
 
     # get device community and version or use default
-    my $host    = $entry->id->address;
-    my $comm    = $entry->snmp_com() || $self->config->{snmp_community};
-    my $version = $entry->snmp_ver() || $self->config->{snmp_version};
+    my $host           = $entry->id->address;
+    my $comm           = $entry->snmp_com() || $self->config->{snmp_community};
+    my $version        = $entry->snmp_ver() || $self->config->{snmp_version};
+    my $mat_force_vlan = $self->config->{mat_force_vlan};
 
     my $source = Manoc::Netwalker::Source::SNMP->new(
         host      => $host,
         community => $comm,
         version   => $version,
+        mat_force_vlan => $mat_force_vlan,
         ) or return undef;
 
     unless($source->connect){

--- a/lib/Manoc/Netwalker/Source/SNMP.pm
+++ b/lib/Manoc/Netwalker/Source/SNMP.pm
@@ -46,6 +46,11 @@ has 'snmp_info' => (
     builder => '_build_snmp_info',
 );
 
+has 'mat_force_vlan' => (
+    is      => 'ro',
+    isa     => 'Str',
+);
+
 #-----------------------------------------------------------------------#
 sub _build_snmp_info {
     my $self = shift;
@@ -187,6 +192,7 @@ sub _build_mat {
     my $fw_port    = $info->fw_port();
     my $fw_status  = $info->fw_status();
     my $bp_index   = $info->bp_index();
+    my $mat_force_vlan = $self->mat_force_vlan || undef;
 
     my ( $status, $mac, $bp_id, $iid, $port );
     my $mat = {};
@@ -215,6 +221,8 @@ sub _build_mat {
             my $vlan = $i_vlan->{$key};
             $vlans{$vlan}++;
         }
+        defined $mat_force_vlan and 
+            $vlans{$mat_force_vlan}++;
 
         # For each VLAN: connect, get mat and merge
         while ( my ( $vid, $vlan_name ) = each(%$v_name) ) {


### PR DESCRIPTION
Now is possible to define a configuration parameter (mat_force_vlan in Netwalker configuration settings)  in order to specify a VLAN number that will force the netwalker to retrive the MAT table of that VLAN 